### PR TITLE
Fixes in the timer initialization

### DIFF
--- a/src/components/timer.js
+++ b/src/components/timer.js
@@ -6,6 +6,7 @@ class Timer extends Component {
     super(props);
 
     this.state = {
+      years: 0,
       days: 0,
       hours: 0,
       min: 0,
@@ -33,12 +34,11 @@ class Timer extends Component {
     if (diff <= 0) return false;
 
     const timeLeft = {
-      years: 1,
-      days: 1,
+      years: 0,
+      days: 0,
       hours: 0,
       min: 0,
-      sec: 0,
-      millisec: 0,
+      sec: 0
     };
 
     // calculate time difference between now and expected date

--- a/src/components/timer.js
+++ b/src/components/timer.js
@@ -80,17 +80,26 @@ class Timer extends Component {
 
     return (
       <div className="Countdown">
+        {countDown.years > 0 && (
+          <span className="Countdown-col">
+            <span className="Countdown-col-element">
+              <strong>{this.addLeadingZeros(countDown.years)}</strong>
+              <span>{countDown.years === 1 ? 'Year' : 'Years'}</span>
+            </span>
+          </span>
+        )}
+
         <span className="Countdown-col">
           <span className="Countdown-col-element">
-              <strong>{this.addLeadingZeros(countDown.days)}</strong>
-              <span>{countDown.days === 1 ? 'Day' : 'Days'}</span>
+            <strong>{this.addLeadingZeros(countDown.days)}</strong>
+            <span>{countDown.days === 1 ? 'Day' : 'Days'}</span>
           </span>
         </span>
 
         <span className="Countdown-col">
           <span className="Countdown-col-element">
             <strong>{this.addLeadingZeros(countDown.hours)}</strong>
-            <span>Hours</span>
+            <span>{countDown.hours === 1 ? 'Hour' : 'Hours'}</span>
           </span>
         </span>
 

--- a/src/components/timer.js
+++ b/src/components/timer.js
@@ -15,10 +15,15 @@ class Timer extends Component {
   }
 
   componentDidMount() {
-    // update every second
+    const endDate = this.props.date;
+
+    // Initialize countdown for the first time
+    this.setState(this.calculateCountdown(endDate));
+
+    // Update every second
     this.interval = setInterval(() => {
-      const date = this.calculateCountdown(this.props.date);
-      date ? this.setState(date) : this.stop();
+      const countdown = this.calculateCountdown(endDate);
+      countdown ? this.setState(countdown) : this.stop();
     }, 1000);
   }
 

--- a/src/components/timer.js
+++ b/src/components/timer.js
@@ -1,4 +1,4 @@
-import React, {  Component } from 'react';
+import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 
 class Timer extends Component {
@@ -59,7 +59,7 @@ class Timer extends Component {
       diff -= timeLeft.min * 60;
     }
     timeLeft.sec = diff;
-   
+
     return timeLeft;
   }
 
@@ -114,11 +114,11 @@ class Timer extends Component {
 }
 
 Timer.propTypes = {
-    date: PropTypes.string.isRequired
-  };
-  
+  date: PropTypes.string.isRequired
+};
+
 Timer.defaultProps = {
-    date: "10/30/2018"
+  date: "10/31/2018 22:30"
 };
 
 export default Timer;


### PR DESCRIPTION
This pull request fixes a couple of issues with the timer initialization which led to undesired behaviours. The addressed issues are described bellow.

* **Year and day counter were been initialized to 1.** 

This caused the countdown to take the wrong values, as for two dates with just an hour of difference the timer would show there was 1 day and 1 hour left. 

* **The countdown wasn't initialized when the application started.**

The `componentDidMount` handler of the `Timer` component didn't update the state with the actual countdown until `setInterval` triggered the function it received as parameter for the first time. This meant there was a delay of one second from the time the component was mounted to the time it updated its state with the countdown values.

When the application launched, the user could see all of the values in the counter set to zero and then suddenly increasing after a second. 

* **The year data was calculated, but never displayed.**

Although this was not really a bug, the component state was keeping a year property which was never been used. I modified the component view so the year count is also displayed when necessary. 